### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This template is compatible with the latest **stable** version of Android Studio
 1. Clone this branch
 
 ```
-git clone https://github.com/android/architecture-templates.git --branch base
+git clone https://github.com/android/architecture-templates.git --branch multimodule
 ```
 
 


### PR DESCRIPTION
Fix a typo in the `git clone` command in the README.md file.

It says to use `--branch base` when it should be `--branch multimodule`.