### PR TITLE
Small fixes in MyModelViewModelTest

### DIFF
--- a/app/src/test/java/android/template/ui/mymodel/MyModelViewModelTest.kt
+++ b/app/src/test/java/android/template/ui/mymodel/MyModelViewModelTest.kt
@@ -36,13 +36,13 @@ class MyModelViewModelTest {
     @Test
     fun uiState_initiallyLoading() = runTest {
         val viewModel = MyModelViewModel(FakeMyModelRepository())
-        assertEquals(viewModel.uiState.first(), MyModelUiState.Loading)
+        assertEquals(MyModelUiState.Loading, viewModel.uiState.first())
     }
 
     @Test
     fun uiState_onItemSaved_isDisplayed() = runTest {
         val viewModel = MyModelViewModel(FakeMyModelRepository())
-        assertEquals(viewModel.uiState.first(), MyModelUiState.Loading)
+        assertEquals(MyModelUiState.Loading, viewModel.uiState.first())
     }
 }
 

--- a/app/src/test/java/android/template/ui/mymodel/MyModelViewModelTest.kt
+++ b/app/src/test/java/android/template/ui/mymodel/MyModelViewModelTest.kt
@@ -17,14 +17,22 @@
 package android.template.ui.mymodel
 
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import android.template.data.MyModelRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -33,27 +41,39 @@ import android.template.data.MyModelRepository
  */
 @OptIn(ExperimentalCoroutinesApi::class) // TODO: Remove when stable
 class MyModelViewModelTest {
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     @Test
     fun uiState_initiallyLoading() = runTest {
         val viewModel = MyModelViewModel(FakeMyModelRepository())
-        assertEquals(MyModelUiState.Loading, viewModel.uiState.first())
+        assertEquals(MyModelUiState.Loading, viewModel.uiState.value)
+        assertEquals(MyModelUiState.Success(emptyList()), viewModel.uiState.first())
     }
 
     @Test
     fun uiState_onItemSaved_isDisplayed() = runTest {
         val viewModel = MyModelViewModel(FakeMyModelRepository())
-        assertEquals(MyModelUiState.Loading, viewModel.uiState.first())
+        assertEquals(MyModelUiState.Loading, viewModel.uiState.value)
+        assertEquals(MyModelUiState.Success(emptyList()), viewModel.uiState.first())
     }
 }
 
 private class FakeMyModelRepository : MyModelRepository {
 
-    private val data = mutableListOf<String>()
+    private val data = MutableStateFlow(emptyList<String>())
 
-    override val myModels: Flow<List<String>>
-        get() = flow { emit(data.toList()) }
+    override val myModels: StateFlow<List<String>> = data.asStateFlow()
 
     override suspend fun add(name: String) {
-        data.add(0, name)
+        data.update { it.plus(name) }
     }
 }

--- a/app/src/test/java/android/template/ui/mymodel/MyModelViewModelTest.kt
+++ b/app/src/test/java/android/template/ui/mymodel/MyModelViewModelTest.kt
@@ -62,8 +62,9 @@ class MyModelViewModelTest {
     @Test
     fun uiState_onItemSaved_isDisplayed() = runTest {
         val viewModel = MyModelViewModel(FakeMyModelRepository())
-        assertEquals(MyModelUiState.Loading, viewModel.uiState.value)
         assertEquals(MyModelUiState.Success(emptyList()), viewModel.uiState.first())
+        viewModel.addMyModel("Compose")
+        assertEquals(MyModelUiState.Success(listOf("Compose")), viewModel.uiState.first())
     }
 }
 


### PR DESCRIPTION
As things are currently, the `MyModelViewModelTest` gives the impression of being a useful starting point, but ultimately leaves a lot to be desired. It has 2 tests with different names that have the same logic, and as soon as you go to update the second test to do what it says it does, the `FakeMyModelRepository` implementation doesn't act as one would reasonably expect (you can call `addMyModel` all you want, but still the only thing that was ever emitted was an empty list).

This PR aims to make the class more correct and helpful. Please see individual commits which should be self-explanatory.