### PR TITLE
Fix branch name in clone command in multimodule README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This template is compatible with the latest **stable** version of Android Studio
 1. Clone this branch
 
 ```
-git clone https://github.com/android/architecture-templates.git --branch base
+git clone https://github.com/android/architecture-templates.git --branch multimodule
 ```
 
 


### PR DESCRIPTION
The clone command in the multimodule README points at the `base` branch instead of the `multimodule` branch. This PR fixes this.